### PR TITLE
Applied strict_types to the callback in internal function args

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -403,6 +403,22 @@ void zend_init_compiler_data_structures(void) /* {{{ */
 }
 /* }}} */
 
+bool zend_arg_uses_strict_types(void) { /* {{{ */
+	if (!EG(current_execute_data)->prev_execute_data) {
+		return false;
+	}
+
+	if (!EG(current_execute_data)->prev_execute_data->opline) {
+		return EG(current_execute_data)->prev_execute_data->prev_execute_data && \
+			EG(current_execute_data)->prev_execute_data->prev_execute_data->func && \
+			ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data->prev_execute_data)
+	}
+
+	return EG(current_execute_data)->prev_execute_data->func && \
+		ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data)
+}
+/* }}} */
+
 static void zend_register_seen_symbol(zend_string *name, uint32_t kind) {
 	zval *zv = zend_hash_find(&FC(seen_symbols), name);
 	if (zv) {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -411,11 +411,11 @@ bool zend_arg_uses_strict_types(void) { /* {{{ */
 	if (!EG(current_execute_data)->prev_execute_data->opline) {
 		return EG(current_execute_data)->prev_execute_data->prev_execute_data && \
 			EG(current_execute_data)->prev_execute_data->prev_execute_data->func && \
-			ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data->prev_execute_data)
+			ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data->prev_execute_data);
 	}
 
 	return EG(current_execute_data)->prev_execute_data->func && \
-		ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data)
+		ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data);
 }
 /* }}} */
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -638,10 +638,7 @@ ZEND_STATIC_ASSERT(ZEND_MM_ALIGNED_SIZE(sizeof(zval)) == sizeof(zval),
 #define EX_USES_STRICT_TYPES() \
 	ZEND_CALL_USES_STRICT_TYPES(execute_data)
 
-#define ZEND_ARG_USES_STRICT_TYPES() \
-	(EG(current_execute_data)->prev_execute_data && \
-	 EG(current_execute_data)->prev_execute_data->func && \
-	 ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data)->prev_execute_data))
+#define ZEND_ARG_USES_STRICT_TYPES() (zend_arg_uses_strict_types())
 
 #define ZEND_RET_USES_STRICT_TYPES() \
 	ZEND_CALL_USES_STRICT_TYPES(EG(current_execute_data))
@@ -779,6 +776,8 @@ BEGIN_EXTERN_C()
 void init_compiler(void);
 void shutdown_compiler(void);
 void zend_init_compiler_data_structures(void);
+
+bool zend_arg_uses_strict_types(void);
 
 void zend_oparray_context_begin(zend_oparray_context *prev_context);
 void zend_oparray_context_end(zend_oparray_context *prev_context);


### PR DESCRIPTION
Taking advantage of the fact that `execute_data->opline` is `0x0` when executing the internal function, in that case the information of `prev_execute_data` one more before is used to determine `strict_types`.

All internal functions that require callback as an argument are affected.

Test code:
```
<?php
declare(strict_types=1);

$arr = ["1"];
$arr2 = array_map(function (int $val) {
    return $val;
}, $arr);
```

Result of building and running the modified code:
```
Fatal error: Uncaught TypeError: {closure}(): Argument #1 ($val) must be of type int, string given in /var/www/html/test.php:5
Stack trace:
#0 [internal function]: {closure}('1')
#1 /var/www/html/test.php(5): array_map(Object(Closure), Array)
#2 {main}
  thrown in /var/www/html/test.php on line 5
```